### PR TITLE
Reject invalid VOC sensor data with checksum errors

### DIFF
--- a/test_VOC-CO2-HCHO-Sensor.cpp
+++ b/test_VOC-CO2-HCHO-Sensor.cpp
@@ -409,7 +409,8 @@ void parseVOCData(uint8_t* buffer, int length, VOCData &data) {
 
   // 验证校验和
   if (frame[8] != checksum) {
-    Serial.printf("⚠️ 校验和不匹配，但继续解析数据 (接收: 0x%02X, 计算: 0x%02X)\n", frame[8], checksum);
+    Serial.printf("⚠️ 校验和不匹配，丢弃数据 (接收: 0x%02X, 计算: 0x%02X)\n", frame[8], checksum);
+    return; // 校验失败时直接返回，保持data.valid为false
   }
 
   // 按照文档协议解析数据


### PR DESCRIPTION
## Summary
- ensure VOC sensor frames with bad checksums are discarded before parsing

## Testing
- `g++ -std=c++17 -c test_VOC-CO2-HCHO-Sensor.cpp` *(fails: Arduino.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c97074b483258e9023bbc7c1f0a3