### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,4 +50,4 @@ esphome run voc-esp32c3.yaml --device OTA
 esphome run cam-esp32s3.yml --device OTA
 esphome run bmp_aht_esp32c3.yaml --device OTA
 esphome run radar-esp32c3.yaml --device OTA
-那个注意一下啊，esp32c3的12,13是它的led的，所以你在这里输入高电频的话，那个led会闪烁
+那个注意一下啊，esp32c3的12,13是它的led的，所以你在这里输入高电平的话，那个led会闪烁


### PR DESCRIPTION
## Summary
- fix typo in README: 高电频 -> 高电平

## Testing
- `pytest`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ce6a5a9c83259df3193035701e33